### PR TITLE
Add a bash script that can be used to set shared settings

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,34 @@
+## Perl dependencies
+
+```shell
+cpanm Dist::Zilla
+dzil authordeps | cpanm
+dzil listdeps | cpanm
+```
+
+## Run tests
+
+Run the tests using the `prove` test harness:
+
+```shell
+# run tests on both the t/ and xt/ directories
+prove -lvr t xt
+```
+
+Run tests using Dist::Zilla:
+```shell
+dzil test --all
+```
+
+## Coverage on a branch
+
+Requirements:
+
+```shell
+cpanm Devel::Cover Pod::Coverage
+```
+
+```shell
+. $PATH_TO_DEVOPS/ENV.sh  # source the environment
+renard_run_cover_on_branch [branch-name]
+```

--- a/ENV.sh
+++ b/ENV.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+main() {
+	_check_if_being_sourced;
+	_check_directory_with_all_repos;
+
+	export RENARD_TEST_DATA_PATH=$(_repo_dir "test-data")
+}
+
+_repo_dir () {
+	DIR_NAME="$1"
+	_check_directory_with_all_repos;
+	if [ "$RENARD_IN_WRAPPER" ]; then
+		echo "$RENARD_ALL_REPO_DIR/$DIR_NAME/$DIR_NAME"
+	else
+		echo "$RENARD_ALL_REPO_DIR/$DIR_NAME"
+	fi
+}
+
+_check_source_env_script_dir () {
+	# works in sourced files, only works for bash
+	export RENARD_ENV_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+}
+
+_check_in_wrapper () {
+	if [ -n "$RENARD_IN_WRAPPER" ]; then
+		# already calculated
+		return
+	fi
+
+	_check_source_env_script_dir;
+	LAST_PART_OF_PATH=$(basename $RENARD_ENV_SCRIPT_DIR)
+	DIR_ABOVE_ENV_SCRIPT_DIR=$(cd .. && pwd)
+	if [ $(basename $DIR_ABOVE_ENV_SCRIPT_DIR) = $LAST_PART_OF_PATH ]; then
+		export RENARD_IN_WRAPPER=1
+	else
+		export RENARD_IN_WRAPPER=0
+	fi
+
+}
+
+_check_directory_with_all_repos () {
+	if [ -n "$RENARD_ALL_REPO_DIR" ]; then
+		# already calculated
+		return
+	fi
+
+	_check_in_wrapper;
+	if [ $RENARD_IN_WRAPPER ]; then
+		# We are in the wrapper
+		export RENARD_ALL_REPO_DIR=$( cd ../.. && pwd )
+	else
+		export RENARD_ALL_REPO_DIR=$( cd .. && pwd )
+	fi
+}
+
+
+_check_if_being_sourced () {
+	if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+		echo "Sourcing ${BASH_SOURCE[0]}"
+	else
+		cat <<USAGE
+You must source the script:
+
+  . ${0}
+USAGE
+		exit 1
+	fi
+}
+
+
+## renard_run_cover_on_branch
+##
+## Syntax
+##
+##   renard_run_cover_on_branch [branch] [command]
+##
+## Example
+##
+##   renard_run_cover_on_branch master
+##
+##   renard_run_cover_on_branch feat/foo
+##
+## Runs the tests using prove on a given branch
+## (or the current branch if none is given).
+##
+## Requires: Devel::Cover
+##
+##     cpanm Devel::Cover
+##
+## Recommends: Pod::Coverage
+##
+##     cpanm Pod::Coverage
+renard_run_cover_on_branch () {
+	_check_in_wrapper;
+	BRANCH="$1";
+	if [ -z "$BRANCH" ]; then
+		# set branch to the name of the current branch
+		BRANCH=`git rev-parse --abbrev-ref HEAD`
+	fi
+
+	COVER_DIR="cover_db/$BRANCH"
+	if [ "$RENARD_IN_WRAPPER" ]; then
+		# move to directory above
+		COVER_DIR="../$COVER_DIR"
+	fi
+	mkdir -p "$COVER_DIR"
+	COVER_DIR=$(cd $COVER_DIR && pwd)
+
+	export HARNESS_PERL_SWITCHES="-MDevel::Cover=-db,$COVER_DIR,+ignore,x?t/"
+	git co $BRANCH
+	cover $COVER_DIR -delete
+	prove -lvr t xt
+	cover $COVER_DIR +ignore '\bt/'
+	see $COVER_DIR/coverage.html
+	export HARNESS_PERL_SWITCHES=""
+}
+
+## renard_run_cover_on_branch_dzil
+##
+## The same as renard_run_cover_on_branch, except using `dzil test` to run
+## the test harness.
+renard_run_cover_on_branch_dzil () {
+	_check_in_wrapper;
+	BRANCH="$1";
+	if [ -z "$BRANCH" ]; then
+		# set branch to the name of the current branch
+		BRANCH=`git rev-parse --abbrev-ref HEAD`
+	fi
+
+	COVER_DIR="cover_db/$BRANCH"
+	if [ "$RENARD_IN_WRAPPER" ]; then
+		# move to directory above
+		COVER_DIR="../$COVER_DIR"
+	fi
+	mkdir -p "$COVER_DIR"
+	COVER_DIR=$(cd $COVER_DIR && pwd)
+
+	export HARNESS_PERL_SWITCHES="-MDevel::Cover=-db,$COVER_DIR,+ignore,x?t/"
+	git co $BRANCH
+	cover $COVER_DIR -delete
+	dzil test --all --keep
+	( cd .build/latest && cover $COVER_DIR )
+	see $COVER_DIR/coverage.html
+	export HARNESS_PERL_SWITCHES=""
+}
+
+
+main;


### PR DESCRIPTION
This script can be used to store environment variables and small helper
functions used to start builds and tests across multiple repos.

The code works for both cases where the directory structure of the Git
repos is both in a single-level directory form:

```
    <top-level>/<repo-name>/.git
```

or in the wrapper directory form

```
    <top-level>/<repo-name>/<repo-name>/.git
```
