### PR TITLE
Add improvements to Vagrant configuration

### DIFF
--- a/VagrantFiles/Vagrantfile
+++ b/VagrantFiles/Vagrantfile
@@ -1,9 +1,36 @@
+def debian_shell_provision( config )
+	config.vm.provision "shell", path: "./os-install-debian"
+	config.vm.provision :shell, privileged: false, path: "./perl-setup"
+	config.vm.provision :shell, privileged: false, path: "./cpan-setup"
+end
+
+org_toplevel = "../.." # /path/to/VagrantFiles/../..
+if Dir.exists?("../../../devops")
+	org_toplevel = "../../.." # the project-renard directory
+end
+
 Vagrant.configure(2) do |config|
-  config.vm.box = "debian/contrib-jessie64"
-  config.ssh.forward_x11 = true
-  config.vm.synced_folder "../../curie/", "/home/vagrant/curie/"
-  config.vm.synced_folder "../../test-data/", "/home/vagrant/test-data/"
-  config.vm.provision "shell", path: "./os-install-debian"
-  config.vm.provision :shell, privileged: false, path: "./perl-setup"
-  config.vm.provision :shell, privileged: false, path: "./cpan-setup"
+	for project_dir in %w[curie test-data devops] do
+		config.vm.synced_folder File.join(org_toplevel, project_dir), "/home/vagrant/project-renard/#{project_dir}"
+	end
+	config.ssh.forward_x11 = true
+
+	config.vm.define :trusty64, primary: true do |trusty|
+		trusty.vm.box = 'ubuntu/trusty64'
+		debian_shell_provision(trusty)
+	end
+
+	config.vm.define :jessie64, autostart: false do |jessie|
+		jessie.vm.box = "debian/contrib-jessie64"
+		debian_shell_provision(jessie)
+	end
+
+	config.vm.define :precise64, autostart: false do |precise|
+		precise.vm.box = "ubuntu/precise64"
+		debian_shell_provision(precise)
+	end
+
+	config.vm.define :osx, autostart: false do |osx|
+		osx.vm.box = "AndrewDryga/vagrant-box-osx"
+	end
 end


### PR DESCRIPTION
- Multi-machine configuration allows for sharing of multiple boxes in
  the same file. By default, `vagrant up` runs the `trusty64` box.
  To run a different box, for example, `jessie64`, run
  `vagrant up jessie64` and to SSH into the `jessie64` box, run
  `vagrant ssh jessie64`. See https://www.vagrantup.com/docs/multi-machine/
  for more information.
- Machines in the configuration:
  - Debian jessie64
  - Ubuntu precise64
  - Ubuntu trusty64 {default} (fixes https://github.com/project-renard/devops/issues/16)
  - Mac OS X (fixes https://github.com/project-renard/devops/issues/12).
- Automatically handles the case where project directories are wrapped
  in an auxiliary directory (e.g., the Git repo is at
  `project-renard/devops/devops` rather than `project-renard/devops`).
